### PR TITLE
Fix memory leak from XQueryTree.

### DIFF
--- a/recorder-bin/src/linux_x11.rs
+++ b/recorder-bin/src/linux_x11.rs
@@ -70,7 +70,7 @@ fn get_top_window_id(display_ptr: *mut x11::xlib::Display, start_window_id: c_ul
             )
         };
 
-        if status == (x11::xlib::Success as i32) {
+        if status != 0 {
             unsafe {
                 x11::xlib::XFree(child_window_ids as *mut c_void);
             };
@@ -171,6 +171,11 @@ fn get_process_id_from_window_tree(
         unsafe {
             x11::xlib::XSetErrorHandler(Some(handle_error_callback));
         }
+        // https://tronche.com/gui/x/xlib/window-information/XQueryTree.html
+        // XQueryTree() returns zero if it fails and nonzero if it succeeds
+        // Comparing with xlib::Success is incorrect as that assumes zero is success
+        // https://docs.rs/x11-dl/2.21.0/x11_dl/xlib/constant.Success.html
+        // pub const Success: c_uchar = 0;
         let status = unsafe {
             x11::xlib::XQueryTree(
                 display_ptr,
@@ -195,7 +200,7 @@ fn get_process_id_from_window_tree(
             }
         }
 
-        if status == (x11::xlib::Success as i32) {
+        if status != 0 {
             unsafe {
                 x11::xlib::XFree(child_window_ids as *mut c_void);
             };


### PR DESCRIPTION
Hi, I wanted to get the process id associated with the window that has focus. I found [this stackoverflow](https://stackoverflow.com/q/151407) and then was like; there must be someone who wrote this... so I found your implementation through github codesearch.

Since it's MIT license I took the liberty of copy pasting [the necessary functions](https://github.com/iwanders/betula/commit/12e183772220a5198b8682fdedaecc1ee24d9a06) into my project. Because it's ffi code I ran it through valgrind and I discovered it was leaking 4 bytes per query. Finding it unfortunately wasn't as easy as I hoped, it didn't show up in the backtrace in valgrind, so I manually had to bisect the code.

The issue is that [XQueryTree](https://tronche.com/gui/x/xlib/window-information/XQueryTree.html) states the following for the return:

> XQueryTree() returns zero if it fails and nonzero if it succeeds.

But the [`xlib::Success`](https://docs.rs/x11-dl/2.21.0/x11_dl/xlib/constant.Success.html) constant is defined as `0`. So on success, the memory isn't correctly freed. Maybe this function breaks with convention? 

Either way, with [this change](https://github.com/iwanders/betula/commit/dcaf5ed098d37599875a67430a3a46938c66bc61) to the code on my side, the memory leak disappears. This PR makes the identical changes to your original code, I did confirm this builds, but haven't tried running the program.